### PR TITLE
Upgrade HTPostingsFormat class using the corresponding PostingsFormat…

### DIFF
--- a/HTPostingsFormatWrapper.java
+++ b/HTPostingsFormatWrapper.java
@@ -25,7 +25,7 @@ import org.apache.lucene.codecs.perfield.PerFieldPostingsFormat; // javadocs
 import org.apache.lucene.index.SegmentWriteState;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.util.NamedSPILoader;
-import org.apache.lucene.codecs.lucene50.Lucene50PostingsFormat;
+import org.apache.lucene.codecs.lucene84.Lucene84PostingsFormat;
 /** 
  *  Wrapper class suggested by Hoss to facilitate loading a Lucene41PostingsFormat 
  *  with non-default min and max Block size params
@@ -38,7 +38,7 @@ public  final class HTPostingsFormatWrapper extends PostingsFormat  {
   
   //values suggested by McCandless email of Jan 10 2015
   //http://lucene.472066.n3.nabble.com/Details-on-setting-block-parameters-for-Lucene41PostingsFormat-tt4178472.html
-   PostingsFormat pf = new Lucene50PostingsFormat(200,398);
+   PostingsFormat pf = new Lucene84PostingsFormat(200,398);
   
   public HTPostingsFormatWrapper() {
     super("HTPostingsFormatWrapper");

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # lss_java_code
 Custom Java code used in HT large scale search
 
-
 ## Files
 The file **HTPostingsFormatWrapper.java** enables HathiTrust search to use less memory for the OCR fields.  
 The file **org.apache.lucene.codecs.PostingsFormat** is a one-line file (aside from the license) that tells the Java SPI loader to load the HTPostingsFormatWrapper.
 
 
 ## What is the problem we are trying to solve
-This code reduces the memory use of a Solr index.  Specificly it reduces the size of the tip file, which is the in-memory index to the indexes on disk.
-
+This code reduces the memory use of a Solr index.  Specifically it reduces the size of the tip file, which is the in-memory index to the indexes on disk.
 
 ## Explanation of code
 
@@ -23,7 +21,6 @@ public  final class HTPostingsFormatWrapper extends PostingsFormat  {
  ...
 ```
 
-
 The code instantiates a postings format with HT specific minimum and maximum block sizes (200,398) instead of the default which is (25,48).  (See BlockTreeTermsWriter.java DEFAULT_MIN_BLOCK_SIZE and DEFAULT_MAX_BLOCK_SIZE.)
 
 In Solr 4 and above there is one index file that contains an entry for every term called the "tim" file.  Lucene has an in-memory index to the "tim" file called the "tip" file.  The "tip" file holds pointers to the blocks in the "tim" file.  
@@ -36,11 +33,14 @@ See *Background details* (below) for more details
 
 ### Creating a special jar file.
 
-Before creating the jar file you should check the Java version accepted by Solr. For example, for Solr 8.11 the recommended version of Java is hihger that 9, however higher than 11 the jar failed, then the maximun version of java you can use for generating the jas is 11.
+For best results, compile using the same version of Java that you will use to run Solr. For Solr 8.11, JDK 11 is recommended.
 
 1.   Compile  "HTPostingsFormatWrapper.java"
-2.   Copy the HTPostingsFormatWrapper.class file to a new empty directory
-3.    In that directory create the following subdirectories
+   * Download Lucene 8.11, Find [here](https://lucene.apache.org/core/downloads.html) Lucene releases. 
+   * Use this command to generate HTPostingsFormatWrapper.class 
+     `javac -cp lucene-8.11.2/core/lucene-core-8.11.2.jar HTPostingsFormatWrapper.java`
+2.   Copy the HTPostingsFormatWrapper.class file to a new empty directory 
+3.   In that directory create the following subdirectories
 
    * META-INF
    * META-INF/services
@@ -72,7 +72,7 @@ jar -tvf HTPostingsFormatWrapper.jar
 ```
 ### Deployment
 
-Put the resulting jar file in the SOLR_HOME/lib directory.  In production we put this in a shared directory and put symlinks in the directory for each core.  
+Put the resulting jar file in the SOLR_HOME/lib directory.  In production, we put this in a shared directory and put symlinks in the directory for each core.  
 For example 
 ```
 /htsolr/lss/shared/lib/HTPostingsFormat.jar
@@ -81,20 +81,20 @@ For example
 
 ## Recompiling for later versions of Solr/Lucene
 
-I aways check the release notes for changes between the version we are running on and any new version we want to upgrade to try to determine if there are any significant changes.  
+I always check the release notes for changes between the version we are running on and any new version we want to upgrade to try to determine if there are any significant changes.  
 Assuming no major changes to the API in future Solr versions the main change would be to update the following line to the appropriate newer PostingsFormat:
 
 PostingsFormat pf = new Lucene50PostingsFormat(200,398);
 
-After the move from Solr/Lucene 4.1 to Solr/Lucene 5, the PostingsFormat has remained stable.  However the best thing to check besides release notes is the JavaDoc for the base PostingsFormat class.  For example for Solr 8.3 (http://lucene.apache.org/core/8_3_0/core/org/apache/lucene/codecs/PostingsFormat.html) you can see in the JavaDoc that the two "Direct Known Subclasses" are Lucene50PostingsFormat and PerFieldPostingsFormat.  If there were a Lucene83PostingsFormat listed, it would be the one to use.
+After the move from Solr/Lucene 4.1 to Solr/Lucene 5, the PostingsFormat has remained stable.  However, the best thing to check besides release notes is the JavaDoc for the base PostingsFormat class.  For example for Solr 8.3 (http://lucene.apache.org/core/8_3_0/core/org/apache/lucene/codecs/PostingsFormat.html) you can see in the JavaDoc that the two "Direct Known Subclasses" are Lucene50PostingsFormat and PerFieldPostingsFormat.  If there were a Lucene83PostingsFormat listed, it would be the one to use.
 
 ## Background details
 
 Because HathiTrust has volumes in over 400 languages, dirty OCR, we use bigrams and unigrams for CJK, and we use CommonGrams for efficient phrase search, the indexes tend to have over 2 billion unique terms. There is an index file which contains one entry for each unique term in an index.  In order to speed up access to this file there is a second file which is read into memory and contains pointers to the file on disk for every Nth term.
 
-Prior to Solr 4 there were settings in solrconfig.xml that could be used to reduce the memory impact of large numbers of terms by changing N ( See https://www.hathitrust.org/blogs/large-scale-search/too-many-words  and https://www.hathitrust.org/blogs/large-scale-search/too-many-words-again for background and how we solved this problem prior to Solr 4)
+Prior to Solr 4 there were settings in solrconfig.xml that could be used to reduce the memory impact of large numbers of terms by changing N ( See https://www.hathitrust.org/the-collection/preservation/large-scale-search/ for background and how we solved this problem prior to Solr 4)
 
-In Solr 4 a much more efficient index struture was adopted using FST's and the ability to change settings in solrconfig.xml to deal with a very large number of unique terms was removed (Because no one but us seems to have this order of magnitude of unique terms).  
+In Solr 4 a much more efficient index structure was adopted using FST's and the ability to change settings in solrconfig.xml to deal with a very large number of unique terms was removed (Because no one but us seems to have this order of magnitude of unique terms).  
 
 As a replacement for making a change in the solrconfig.xml file we  need this Solr "plugin" which uses the JAVA Service Provider Interface (SPI) to tell Solr to use the provided code. See https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html
 
@@ -110,7 +110,7 @@ See https://lucene.apache.org/core/6_6_0/core/org/apache/lucene/codecs/lucene62/
 
 Part of the reason we have a very large number of unique terms per index (shard), is that we currently spread the index over 12 shards.  So each index holds over a million very large documents.  Our indexes are now close to a terabyte in size.  Very few Solr users have indexes over about 100GB.
 
-With the move to AWS, we have the possiblity of testing a deployment that is more like most of the users of Solr.  We might want to experiment with spreading the index over 60 or 100 shards.  If we do that, we could test to see if we still have an issue with memory and too many unique terms per shard.
+With the move to AWS, we have the possibility of testing a deployment that is more like most of the users of Solr.  We might want to experiment with spreading the index over 60 or 100 shards.  If we do that, we could test to see if we still have an issue with memory and too many unique terms per shard.
 
 ### Tuning the block size settings
 It should be possible to fine-tune the block size.  There is a trade-off between memory use and the number of disk accesses. Testing with the previous (Solr before 4.0) version showed that the increase in number of disk accesses was insignificant in terms of overall query response time.  If a similar test with Solr 6 or above shows a similar lack of significant performance penalty, and memory use does not need to be further reduced, further tuning would be unnecessary.
@@ -147,5 +147,3 @@ max=398?  However, block tree should have been more RAM efficient than
 additional details about the block structure of your terms indices...
 
 Mike McCandless"
-
-

--- a/README.md
+++ b/README.md
@@ -36,16 +36,19 @@ See *Background details* (below) for more details
 
 ### Creating a special jar file.
 
+Before creating the jar file you should check the Java version accepted by Solr. For example, for Solr 8.11 the recommended version of Java is hihger that 9, however higher than 11 the jar failed, then the maximun version of java you can use for generating the jas is 11.
+
 1.   Compile  "HTPostingsFormatWrapper.java"
 2.   Copy the HTPostingsFormatWrapper.class file to a new empty directory
 3.    In that directory create the following subdirectories
 
    * META-INF
    * META-INF/services
+   * META-INF/versions
    * org/apache/lucene/codecs
 
 4.   Put the **HTPostingsFormatWrapper.class** file in **org/apache/lucene/codecs**
-5.   Put the **org.apache.lucene.codecs.PostingsFormat** file in **META-INF/services**
+5.   Put the **org.apache.lucene.codecs.PostingsFormat** file in **META-INF/services** and in **META-INF/versions** 
 
 6.   Create a jar:
 


### PR DESCRIPTION
This PR updates HTPostingFormat class to use the corresponding version of Lucene 8.11. The previous code was created used Lucene 5, then the code have to be upgrade to generate new jars compatibles with Solr 8.11. The README file was also updated